### PR TITLE
Make private kitchen, bathroom and step-free nullable

### DIFF
--- a/Hackney.Shared.HousingSearch/Domain/Asset/AssetCharacteristics.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/AssetCharacteristics.cs
@@ -4,10 +4,10 @@
     {
         public static AssetCharacteristics Create(int numberOfBedrooms, int numberOfLifts, int numberOfLivingRooms, string windowType, string yearConstructed, string assetPropertyFolderLink,
         string epcExpiryDate, string fireSafetyCertificateExpiryDate, string gasSafetyCertificateExpiryDate, string elecCertificateExpiryDate,
-        bool optionToTax, bool hasStairs, int numberOfStairs, bool hasRampAccess, bool hasCommunalAreas, bool hasPrivateBathroom,
-        int numberOfBathrooms, string bathroomFloor, bool hasPrivateKitchen, int numberOfKitchens, string kitchenfloor,
+        bool optionToTax, bool hasStairs, int numberOfStairs, bool hasRampAccess, bool hasCommunalAreas, bool? hasPrivateBathroom,
+        int numberOfBathrooms, string bathroomFloor, bool? hasPrivateKitchen, int numberOfKitchens, string kitchenfloor,
         string alertSystemExpiryDate, string epcScore, int numberOfFloors, string accessibilityComments, int numberOfBedSpaces, int numberOfCots,
-        string sleepingArrangementNotes, int numberOfShowers, string kitchenNotes, bool isStepFree)
+        string sleepingArrangementNotes, int numberOfShowers, string kitchenNotes, bool? isStepFree)
         {
             return new AssetCharacteristics(
                 numberOfBedrooms,
@@ -48,10 +48,10 @@
         private AssetCharacteristics(int numberOfBedrooms, int numberOfLifts, int numberOfLivingRooms, string windowType,
             string yearConstructed, string assetPropertyFolderLink, string epcExpiryDate, string fireSafetyCertificateExpiryDate,
             string gasSafetyCertificateExpiryDate, string elecCertificateExpiryDate, bool optionToTax, bool hasStairs, int numberOfStairs,
-            bool hasRampAccess, bool hasCommunalAreas, bool hasPrivateBathroom, int numberOfBathrooms, string bathroomFloor,
-            bool hasPrivateKitchen, int numberOfKitchens, string kitchenfloor, string alertSystemExpiryDate, string epcScore,
+            bool hasRampAccess, bool hasCommunalAreas, bool? hasPrivateBathroom, int numberOfBathrooms, string bathroomFloor,
+            bool? hasPrivateKitchen, int numberOfKitchens, string kitchenfloor, string alertSystemExpiryDate, string epcScore,
             int numberOfFloors, string accessibilityComments, int numberOfBedSpaces, int numberOfCots, string sleepingArrangementNotes,
-            int numberOfShowers, string kitchenNotes, bool isStepFree)
+            int numberOfShowers, string kitchenNotes, bool? isStepFree)
         {
             NumberOfBedrooms = numberOfBedrooms;
             NumberOfLifts = numberOfLifts;
@@ -101,10 +101,10 @@
         public int NumberOfStairs { get; set; }
         public bool HasRampAccess { get; set; }
         public bool HasCommunalAreas { get; set; }
-        public bool HasPrivateBathroom { get; set; }
+        public bool? HasPrivateBathroom { get; set; }
         public int NumberOfBathrooms { get; set; }
         public string BathroomFloor { get; set; }
-        public bool HasPrivateKitchen { get; set; }
+        public bool? HasPrivateKitchen { get; set; }
         public int NumberOfKitchens { get; set; }
         public string Kitchenfloor { get; set; }
         public string AlertSystemExpiryDate { get; set; }
@@ -116,6 +116,6 @@
         public string SleepingArrangementNotes { get; set; }
         public int NumberOfShowers { get; set; }
         public string KitchenNotes { get; set; }
-        public bool IsStepFree { get; set; }
+        public bool? IsStepFree { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetCharacteristics.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetCharacteristics.cs
@@ -17,10 +17,10 @@
         public int NumberOfStairs { get; set; }
         public bool HasRampAccess { get; set; }
         public bool HasCommunalAreas { get; set; }
-        public bool HasPrivateBathroom { get; set; }
+        public bool? HasPrivateBathroom { get; set; }
         public int NumberOfBathrooms { get; set; }
         public string BathroomFloor { get; set; }
-        public bool HasPrivateKitchen { get; set; }
+        public bool? HasPrivateKitchen { get; set; }
         public int NumberOfKitchens { get; set; }
         public string Kitchenfloor { get; set; }
         public string AlertSystemExpiryDate { get; set; }
@@ -32,6 +32,6 @@
         public string SleepingArrangementNotes { get; set; }
         public int NumberOfShowers { get; set; }
         public string KitchenNotes { get; set; }
-        public bool IsStepFree { get; set; }
+        public bool? IsStepFree { get; set; }
     }
 }


### PR DESCRIPTION
### What
The respective fields within the Asset Characteristic sub-model has been made nullable:

- `HasPrivateBathroom`
- `HasPrivateKitchen`
- `IsStepFree`

### Why
To accurately display the correct information on the BTA application when searching for assets these fields need to be able to be null. C# booleans by default set null fields to false which in turn displays the wrong information when the aforementioned fields are not set.