### PR TITLE
[TS-1501] extend AssetContract with additional fields

### DIFF
--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -59,6 +59,8 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
+            domainContract.Charges.Should().BeEquivalentTo(queryableAssetContract.Charges);
+            domainContract.RelatedPeople.Should().BeEquivalentTo(queryableAssetContract.RelatedPeople);
         }
 
         [Fact]

--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -1,6 +1,8 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Hackney.Shared.HousingSearch.Factories;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 using Xunit;
 
@@ -43,6 +45,47 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainTAOfficer.Email.Should().Be(queryableTAOfficer.Email);
             domainTAOfficer.FirstName.Should().Be(queryableTAOfficer.FirstName);
             domainTAOfficer.LastName.Should().Be(queryableTAOfficer.LastName);
+        }
+
+        [Fact]
+        public void CanConvertQueryableAssetContractEntityToDomain()
+        {
+            var queryableAssetContract = _fixture.Create<QueryableAssetContract>();
+
+            var domainContract = queryableAssetContract.ToDomain();
+
+            domainContract.Id.Should().Be(queryableAssetContract.Id);
+            domainContract.TargetId.Should().Be(queryableAssetContract.TargetId);
+            domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
+            domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
+            domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
+        }
+
+        [Fact]
+        public void CanConvertQueryableChargesEntityToDomain()
+        {
+            var queryableCharge = _fixture.Create<QueryableCharges>();
+
+            var domainCharge = queryableCharge.ToDomain();
+
+            domainCharge.Id.Should().Be(queryableCharge.Id);
+            domainCharge.Type.Should().Be(queryableCharge.Type);
+            domainCharge.SubType.Should().Be(queryableCharge.SubType);
+            domainCharge.Frequency.Should().Be(queryableCharge.Frequency);
+            domainCharge.Amount.Should().Be(queryableCharge.Amount);
+        }
+
+        [Fact]
+        public void CanConvertQueryableRelatedPeopleEntityToDomain()
+        {
+            var queryableRelatedPerson = _fixture.Create<QueryableRelatedPeople>();
+
+            var domainRelatedPerson = queryableRelatedPerson.ToDomain();
+
+            domainRelatedPerson.Id.Should().Be(queryableRelatedPerson.Id);
+            domainRelatedPerson.Type.Should().Be(queryableRelatedPerson.Type);
+            domainRelatedPerson.SubType.Should().Be(queryableRelatedPerson.SubType);
+            domainRelatedPerson.Name.Should().Be(queryableRelatedPerson.Name);
         }
     }
 }

--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -56,6 +56,7 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
 
             domainContract.Id.Should().Be(queryableAssetContract.Id);
             domainContract.TargetId.Should().Be(queryableAssetContract.TargetId);
+            domainContract.TargetType.Should().Be(queryableAssetContract.TargetType);
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -6,35 +6,6 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
 {
     public class Contract
     {
-        public static Contract Create(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
-            bool? isApproved, IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
-        {
-            return new Contract(
-                id,
-                targetId,
-                targetType,
-                startDate,
-                approvalDate,
-                isApproved,
-                charges,
-                relatedPeople
-            );
-        }
-        public Contract() { }
-
-        private Contract(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
-            bool? isApproved, IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
-        {
-            Id = id;
-            TargetId = targetId;
-            TargetType = targetType;
-            StartDate = startDate;
-            ApprovalDate = approvalDate;
-            IsApproved = isApproved;
-            Charges = charges;
-            RelatedPeople = relatedPeople;
-        }
-
         public string Id { get; set; }
         public string TargetId { get; set; }
         public string TargetType { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -23,7 +23,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public Contract() { }
 
         private Contract(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
-            bool? isApproved,  IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
+            bool? isApproved, IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
         {
             Id = id;
             TargetId = targetId;

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -6,28 +6,42 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
 {
     public class Contract
     {
-        public static Contract Create(string id, string targetId, string targetType, IEnumerable<Charges> charges)
+        public static Contract Create(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
+            bool? isApproved, IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
         {
             return new Contract(
                 id,
                 targetId,
                 targetType,
-                charges
+                startDate,
+                approvalDate,
+                isApproved,
+                charges,
+                relatedPeople
             );
         }
         public Contract() { }
 
-        private Contract(string id, string targetId, string targetType, IEnumerable<Charges> charges)
+        private Contract(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
+            bool? isApproved,  IEnumerable<Charges> charges, IEnumerable<RelatedPeople> relatedPeople)
         {
             Id = id;
             TargetId = targetId;
             TargetType = targetType;
+            StartDate = startDate;
+            ApprovalDate = approvalDate;
+            IsApproved = isApproved;
             Charges = charges;
+            RelatedPeople = relatedPeople;
         }
 
         public string Id { get; set; }
         public string TargetId { get; set; }
         public string TargetType { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? ApprovalDate { get; set; }
+        public bool? IsApproved { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
+        public IEnumerable<RelatedPeople> RelatedPeople { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Charges.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Charges.cs
@@ -1,27 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Hackney.Shared.HousingSearch.Domain.Contract
+﻿namespace Hackney.Shared.HousingSearch.Domain.Contract
 {
     public class Charges
     {
-        public Charges() { }
-
-        public static Charges Create(string id, string type, string subType, string frequency, decimal? amount)
-        {
-            return new Charges(id, type, subType, frequency, amount);
-        }
-
-        private Charges(string id, string type, string subType, string frequency, decimal? amount)
-        {
-            Id = id;
-            Type = type;
-            SubType = subType;
-            Frequency = frequency;
-            Amount = amount;
-        }
-
         public string Id { get; set; }
         public string Type { get; set; }
         public string SubType { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -1,5 +1,4 @@
-﻿using Hackney.Shared.HousingSearch.Domain.Contract;
-using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+﻿using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using System;
 using System.Collections.Generic;
 
@@ -7,28 +6,43 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
 {
     public class Contract
     {
-        public static Contract Create(string id, string targetId, string targetType, IEnumerable<QueryableCharges> charges)
+        public static Contract Create(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
+            bool? isApproved, IEnumerable<QueryableCharges> charges, IEnumerable<QueryableRelatedPeople> relatedPeople)
         {
             return new Contract(
                 id,
                 targetId,
                 targetType,
-                charges
+                startDate,
+                approvalDate,
+                isApproved,
+                charges,
+                relatedPeople
             );
         }
         public Contract() { }
 
-        private Contract(string id, string targetId, string targetType, IEnumerable<QueryableCharges> charges)
+        private Contract(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
+            bool? isApproved, IEnumerable<QueryableCharges> charges, IEnumerable<QueryableRelatedPeople> relatedPeople)
         {
             Id = id;
             TargetId = targetId;
             TargetType = targetType;
+            StartDate = startDate;
+            ApprovalDate = approvalDate;
+            IsApproved = isApproved;
+            TargetType = targetType;
             Charges = charges;
+            RelatedPeople = relatedPeople;
         }
 
         public string Id { get; set; }
         public string TargetId { get; set; }
         public string TargetType { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? ApprovalDate { get; set; }
+        public bool? IsApproved { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
+        public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -6,36 +6,6 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
 {
     public class Contract
     {
-        public static Contract Create(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
-            bool? isApproved, IEnumerable<QueryableCharges> charges, IEnumerable<QueryableRelatedPeople> relatedPeople)
-        {
-            return new Contract(
-                id,
-                targetId,
-                targetType,
-                startDate,
-                approvalDate,
-                isApproved,
-                charges,
-                relatedPeople
-            );
-        }
-        public Contract() { }
-
-        private Contract(string id, string targetId, string targetType, DateTime? startDate, DateTime? approvalDate,
-            bool? isApproved, IEnumerable<QueryableCharges> charges, IEnumerable<QueryableRelatedPeople> relatedPeople)
-        {
-            Id = id;
-            TargetId = targetId;
-            TargetType = targetType;
-            StartDate = startDate;
-            ApprovalDate = approvalDate;
-            IsApproved = isApproved;
-            TargetType = targetType;
-            Charges = charges;
-            RelatedPeople = relatedPeople;
-        }
-
         public string Id { get; set; }
         public string TargetId { get; set; }
         public string TargetType { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
@@ -2,21 +2,6 @@
 {
     public class RelatedPeople
     {
-        public RelatedPeople() { }
-
-        public static RelatedPeople Create(string id, string type, string subType, string name)
-        {
-            return new RelatedPeople(id, type, subType, name);
-        }
-
-        private RelatedPeople(string id, string type, string subType, string name)
-        {
-            Id = id;
-            Type = type;
-            SubType = subType;
-            Name = name;
-        }
-
         public string Id { get; set; }
         public string Type { get; set; }
         public string SubType { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
@@ -3,12 +3,12 @@
     public class RelatedPeople
     {
         public RelatedPeople() { }
-        
+
         public static RelatedPeople Create(string id, string type, string subType, string name)
         {
             return new RelatedPeople(id, type, subType, name);
         }
-        
+
         private RelatedPeople(string id, string type, string subType, string name)
         {
             Id = id;

--- a/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nest;
+
+namespace Hackney.Shared.HousingSearch.Domain.Contract
+{
+    public class RelatedPeople
+    {
+        public RelatedPeople() { }
+        
+        public static RelatedPeople Create(string id, string type, string subType, string name)
+        {
+            return new RelatedPeople(id, type, subType, name);
+        }
+
+        private RelatedPeople(string id, string type, string subType, string name)
+        {
+            Id = id;
+            Type = type;
+            SubType = subType;
+            Name = name;
+        }
+
+        public string Id { get; set; }
+        public string Type { get; set; }
+        public string SubType { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/RelatedPeople.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Nest;
-
-namespace Hackney.Shared.HousingSearch.Domain.Contract
+﻿namespace Hackney.Shared.HousingSearch.Domain.Contract
 {
     public class RelatedPeople
     {
@@ -13,7 +8,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         {
             return new RelatedPeople(id, type, subType, name);
         }
-
+        
         private RelatedPeople(string id, string type, string subType, string name)
         {
             Id = id;

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -111,7 +111,7 @@ namespace Hackney.Shared.HousingSearch.Factories
 
         public static IEnumerable<Charges> ToDomain(this IEnumerable<QueryableCharges> charges)
         {
-            return charges.Select(x => x.ToDomain()).ToList();
+            return charges.Select(x => x.ToDomain());
         }
 
         public static RelatedPeople ToDomain(this QueryableRelatedPeople entity)
@@ -127,7 +127,7 @@ namespace Hackney.Shared.HousingSearch.Factories
 
         public static IEnumerable<RelatedPeople> ToDomain(this IEnumerable<QueryableRelatedPeople> relatedPeople)
         {
-            return relatedPeople.Select(x => x.ToDomain()).ToList();
+            return relatedPeople.Select(x => x.ToDomain());
         }
     }
 }

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -3,9 +3,12 @@ using DomainProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using Hackney.Shared.HousingSearch.Domain.Contract;
 using RelatedEntity = Hackney.Shared.HousingSearch.Domain.Process.RelatedEntity;
 using PatchAssignment = Hackney.Shared.HousingSearch.Domain.Process.PatchAssignment;
 using Hackney.Shared.HousingSearch.Domain.Tenure;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 
 namespace Hackney.Shared.HousingSearch.Factories
@@ -50,8 +53,12 @@ namespace Hackney.Shared.HousingSearch.Factories
                 PatchAssignment = entity.PatchAssignment?.ToDomain(),
                 RelatedEntities = entity.RelatedEntities.ToDomain(),
                 State = entity.State,
-                ProcessStartedAt = (entity.ProcessStartedAt is null ? (DateTime?)null : DateTime.Parse(entity.ProcessStartedAt)),
-                StateStartedAt = (entity.StateStartedAt is null ? (DateTime?)null : DateTime.Parse(entity.StateStartedAt))
+                ProcessStartedAt = (entity.ProcessStartedAt is null
+                    ? (DateTime?)null
+                    : DateTime.Parse(entity.ProcessStartedAt)),
+                StateStartedAt = (entity.StateStartedAt is null
+                    ? (DateTime?)null
+                    : DateTime.Parse(entity.StateStartedAt))
             };
         }
 
@@ -73,6 +80,54 @@ namespace Hackney.Shared.HousingSearch.Factories
                 FirstName = entity.FirstName,
                 LastName = entity.LastName
             };
+        }
+
+        public static Domain.Asset.Contract ToDomain(this QueryableAssetContract entity)
+        {
+            return new Domain.Asset.Contract
+            {
+                Id = entity.Id,
+                TargetId = entity.TargetId,
+                TargetType = entity.TargetType,
+                StartDate = entity.StartDate,
+                ApprovalDate = entity.ApprovalDate,
+                IsApproved = entity.IsApproved,
+                Charges = entity.Charges?.ToDomain(),
+                RelatedPeople = entity.RelatedPeople?.ToDomain(),
+            };
+        }
+
+        public static Charges ToDomain(this QueryableCharges entity)
+        {
+            return new Charges
+            {
+                Id = entity.Id,
+                Type = entity.Type,
+                SubType = entity.SubType,
+                Frequency = entity.Frequency,
+                Amount = entity.Amount
+            };
+        }
+
+        public static IEnumerable<Charges> ToDomain(this IEnumerable<QueryableCharges> charges)
+        {
+            return charges.Select(x => x.ToDomain()).ToList();
+        }
+
+        public static RelatedPeople ToDomain(this QueryableRelatedPeople entity)
+        {
+            return new RelatedPeople
+            {
+                Id = entity.Id,
+                Type = entity.Type,
+                SubType = entity.SubType,
+                Name = entity.Name
+            };
+        }
+
+        public static IEnumerable<RelatedPeople> ToDomain(this IEnumerable<QueryableRelatedPeople> relatedPeople)
+        {
+            return relatedPeople.Select(x => x.ToDomain()).ToList();
         }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Linq;
-using Hackney.Shared.HousingSearch.Domain.Asset;
 using Nest;
 using Asset = Hackney.Shared.HousingSearch.Domain.Asset.Asset;
 
@@ -165,7 +163,11 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                     AssetContract.Id,
                     AssetContract.TargetId,
                     AssetContract.TargetType,
-                    AssetContract.Charges?.Select(p => p.Create()).ToList()
+                    AssetContract.StartDate,
+                    AssetContract.ApprovalDate,
+                    AssetContract.IsApproved,
+                    AssetContract.Charges?.Select(p => p.Create()).ToList(),
+                    AssetContract.RelatedPeople?.Select(p => p.Create()).ToList()
                 );
 
             return Asset.CreateAll(

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using Hackney.Shared.HousingSearch.Factories;
 using Nest;
 using Asset = Hackney.Shared.HousingSearch.Domain.Asset.Asset;
 
@@ -157,18 +157,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                     AssetLocation.FloorNo
                 );
 
-            var contract = AssetContract == null
-                ? null
-                : Domain.Asset.Contract.Create(
-                    AssetContract.Id,
-                    AssetContract.TargetId,
-                    AssetContract.TargetType,
-                    AssetContract.StartDate,
-                    AssetContract.ApprovalDate,
-                    AssetContract.IsApproved,
-                    AssetContract.Charges?.Select(p => p.Create()).ToList(),
-                    AssetContract.RelatedPeople?.Select(p => p.Create()).ToList()
-                );
+            var contract = AssetContract?.ToDomain();
 
             return Asset.CreateAll(
                 Id,
@@ -220,6 +209,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public QueryableAssetManagement AssetManagement { get; set; }
 
         public QueryableAssetLocation AssetLocation { get; set; }
+
         public QueryableAssetContract AssetContract { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -1,8 +1,7 @@
-﻿using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+﻿using System;
+using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Nest;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
 {
@@ -10,13 +9,18 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
     {
         public Domain.Contract.Contract Create()
         {
-            return Domain.Contract.Contract.Create(Id, TargetId, TargetType, Charges);
+            return Domain.Contract.Contract.Create(Id, TargetId, TargetType, StartDate, ApprovalDate, IsApproved,
+                Charges, RelatedPeople);
         }
 
         [Text(Name = "id")]
         public string Id { get; set; }
         public string TargetId { get; set; }
         public string TargetType { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? ApprovalDate { get; set; }
+        public bool? IsApproved { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
+        public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -7,12 +7,6 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
 {
     public class QueryableAssetContract
     {
-        public Domain.Contract.Contract Create()
-        {
-            return Domain.Contract.Contract.Create(Id, TargetId, TargetType, StartDate, ApprovalDate, IsApproved,
-                Charges, RelatedPeople);
-        }
-
         [Text(Name = "id")]
         public string Id { get; set; }
         public string TargetId { get; set; }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableCharges.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableCharges.cs
@@ -1,25 +1,10 @@
-﻿using Hackney.Shared.HousingSearch.Domain.Contract;
-using Nest;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Nest;
 
 namespace Hackney.Shared.HousingSearch.Gateways.Models.Contract
 {
     public class QueryableCharges
     {
-        public Charges Create()
-        {
-            return Charges.Create(
-                Id,
-                Type,
-                SubType,
-                Frequency,
-                Amount
-            );
-        }
-        [Text(Name = "id")]
-        public string Id { get; set; }
+        [Text(Name = "id")] public string Id { get; set; }
         public string Type { get; set; }
         public string SubType { get; set; }
         public string Frequency { get; set; }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableRelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableRelatedPeople.cs
@@ -5,17 +5,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Contract
 {
     public class QueryableRelatedPeople
     {
-        public RelatedPeople Create()
-        {
-            return RelatedPeople.Create(
-                Id,
-                Type,
-                SubType,
-                Name
-            );
-        }
-        [Text(Name = "id")]
-        public string Id { get; set; }
+        [Text(Name = "id")] public string Id { get; set; }
         public string Type { get; set; }
         public string SubType { get; set; }
         public string Name { get; set; }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableRelatedPeople.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Contract/QueryableRelatedPeople.cs
@@ -1,0 +1,23 @@
+﻿using Hackney.Shared.HousingSearch.Domain.Contract;
+using Nest;
+
+namespace Hackney.Shared.HousingSearch.Gateways.Models.Contract
+{
+    public class QueryableRelatedPeople
+    {
+        public RelatedPeople Create()
+        {
+            return RelatedPeople.Create(
+                Id,
+                Type,
+                SubType,
+                Name
+            );
+        }
+        [Text(Name = "id")]
+        public string Id { get; set; }
+        public string Type { get; set; }
+        public string SubType { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

[https://hackney.atlassian.net/browse/TS-1501](https://hackney.atlassian.net/browse/TS-1501)

## Describe this PR

### *What is the problem we're trying to solve*

This is part of the work to extend `housing-search-api` to return additional contract data along with the search search results. The additional data will be used for the Contracts Worktray.

### *What changes have we introduced*

`AssetContract` has been extended to contain the additional fields `startDate`, `approvalDate`, `isApproved` and `relatedPeople`.

The preview package has been tested successfully in housing search listener.

### *Follow up actions after merging PR*

n/a