### PR TITLE
TS-1528: Add isActive to AssetContract

### DIFF
--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -60,6 +60,7 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
+            domainContract.IsActive.Should().Be(queryableAssetContract.IsActive);
             domainContract.Charges.Should().BeEquivalentTo(queryableAssetContract.Charges);
             domainContract.RelatedPeople.Should().BeEquivalentTo(queryableAssetContract.RelatedPeople);
         }

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -12,6 +12,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public bool? IsActive { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
         public IEnumerable<RelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -12,6 +12,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public bool? IsActive { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -92,6 +92,7 @@ namespace Hackney.Shared.HousingSearch.Factories
                 StartDate = entity.StartDate,
                 ApprovalDate = entity.ApprovalDate,
                 IsApproved = entity.IsApproved,
+                IsActive = entity.IsActive,
                 Charges = entity.Charges?.ToDomain(),
                 RelatedPeople = entity.RelatedPeople?.ToDomain(),
             };

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -14,6 +14,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public bool? IsActive { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1528

## Describe this PR

### *What is the problem we're trying to solve*

On BTA, contracts that are inactive and not approved are being displayed on the contracts worktray. To avoid this, we need to expose whether the contract is active or not on the AssetContract subentity in the Housing Search.

### *What changes have we introduced*

Added new field to the Contract/QueryableAssetContract.

### *Follow up actions after merging PR*

Update version on listener and API and changes to propagate and retrieve the new field.