### PR TITLE
TS-1610: Add new ApprovalStatus field to the AssetContract

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-shared-housing-search-test
+        run: docker compose build hackney-shared-housing-search-test
       - name: Run tests
-        run: docker-compose run hackney-shared-housing-search-test
+        run: docker compose run hackney-shared-housing-search-test
 
   publish-package:
     name: Publish Package

--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -60,6 +60,7 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
+            domainContract.ApprovalStatus.Should().Be(queryableAssetContract.ApprovalStatus);
             domainContract.IsActive.Should().Be(queryableAssetContract.IsActive);
             domainContract.Charges.Should().BeEquivalentTo(queryableAssetContract.Charges);
             domainContract.RelatedPeople.Should().BeEquivalentTo(queryableAssetContract.RelatedPeople);

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -1,4 +1,5 @@
 ﻿using Hackney.Shared.HousingSearch.Domain.Contract;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using System;
 using System.Collections.Generic;
 
@@ -12,6 +13,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? IsActive { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
         public IEnumerable<RelatedPeople> RelatedPeople { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -1,4 +1,5 @@
 ﻿using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using System;
 using System.Collections.Generic;
 
@@ -12,6 +13,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? IsActive { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Enums/ApprovalStatus.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Enums/ApprovalStatus.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Hackney.Shared.HousingSearch.Domain.Enums
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ApprovalStatus
+    {
+        PendingApproval,
+        Approved,
+        PendingReapproval
+    }
+}

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -92,6 +92,7 @@ namespace Hackney.Shared.HousingSearch.Factories
                 StartDate = entity.StartDate,
                 ApprovalDate = entity.ApprovalDate,
                 IsApproved = entity.IsApproved,
+                ApprovalStatus = entity.ApprovalStatus,
                 IsActive = entity.IsActive,
                 Charges = entity.Charges?.ToDomain(),
                 RelatedPeople = entity.RelatedPeople?.ToDomain(),

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using Nest;
 using System.Collections.Generic;
 
@@ -14,6 +15,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? IsActive { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1610

## Describe this PR

### *What is the problem we're trying to solve*

BTA users want to be able to reset the contract approval status of an updated approved contract so that it can be submitted for reapproval. This calls for changing from a boolean value to an enum in the Contracts, to account for more than two possible statuses.
We haven't removed the `isApproved` flag yet so that the FE can continue to function until we introduce the new field there too.

### *What changes have we introduced*

New enum field.
Also this includes a fix by @notatiyyah on the docker setup for tests

### *Follow up actions after merging PR*

Updates to the Listener and API.