### PR TITLE
GitHub token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{ secrets.LBHPACKAGESTOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -35,8 +33,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{ secrets.LBHPACKAGESTOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,8 +45,6 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -66,7 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
       VERSION: ${{ needs.build-and-test.outputs.version }}
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,4 +69,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Shared.HousingSearch/bin/Release
-          dotnet nuget push Hackney.Shared.HousingSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Shared.HousingSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/Hackney.Shared.HousingSearch.Tests/Dockerfile
+++ b/Hackney.Shared.HousingSearch.Tests/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,3 @@ services:
     build:
       context: .
       dockerfile: Hackney.Shared.HousingSearch.Tests/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}

--- a/nuget.config
+++ b/nuget.config
@@ -6,11 +6,4 @@
     <add key="github-hackney" value="https://nuget.pkg.github.com/LBHackney-IT/index.json" />
   </packageSources>
 
-  <packageSourceCredentials>
-    <github-hackney>
-      <add key="Username" value="PublicToken" />
-      <add key="ClearTextPassword" value="%LBHPACKAGESTOKEN%" />
-    </github-hackney>
-  </packageSourceCredentials>
-
 </configuration>


### PR DESCRIPTION
## Describe this PR

This PR removes two environment variables which have been used to carry credentials to publish/read packages to our GitHub Packages NuGet registry:

- `LBHPACKAGESTOKEN`
- `NUGET_KEY`

### What is the problem we're trying to solve

Using a personal access token as a GitHub Actions secret for the NuGet package registry was bothering me so I checked [the docs](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-with-granular-permissions). There's now a better way:

> If you're using a registry that supports granular permissions, and your workflow is using a personal access token to authenticate to the registry, then we highly recommend you update your workflow to use the GITHUB_TOKEN.

The NuGet registry supports granular permissions 🤩 .
`GITHUB_TOKEN` is generated and managed by GitHub Actions and  is
automatically set with the appropriate permissions for that repository. Using that secret
also means we won't be bitten by expiring tokens (because all tokens should
have an expiry date) or people leaving and the personal access tokens
losing access.

This change switches to `GITHUB_TOKEN`, which will allow us to deprecate
`LBHPACKAGESTOKEN` secret in GitHub Actions.

Historically we've published packages from our local machines, which requires a token
to authenticate with the GitHub Packages NuGet Registry. Now we use CI to publish
packages that write/publish token is no longer needed.

Hackney's NuGet packages are publicly readable, so a token isn't required to download
dependencies. Therefore we can remove the credentials from the NuGet configuration we 
clone to our dev machines. This also protects us from accidentally pushing/deleting packages locally.

### What changes have we introduced

This PR removes all references to the two secrets (and their use as environment variables), switching to the built-in `GITHUB_TOKEN`.

### Consequences

🚨 This change will break package registry management actions run on dev devices 🚨. If we rarely do this then it might not be a problem (and ideally those tasks could be formalised/upgraded to GitHub Actions workflows), but there are two ways to reinstate that ability:

1. Reinstate the changes into `nuget.config`. This is probably the most appropriate if we do a lot of maintenance tasks locally. If we switched to using `GITHUB_TOKEN` as the environment variable this would make local dev and CI consistent, while retaining the benefits of a GitHub-managed token.
2. Run `nuget` commands with the `--api-key` parameter (as we do in CI [here](https://github.com/LBHackney-IT/housing-search-shared/blob/c70fd93d32d3557907eccf48869550877bdf3e45/.github/workflows/publish.yml#L79). This option makes it more explicit that we're doing a write or destructive action.

#### _Checklist_

- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

- [ ] Remove this repository from the `LBHPACKAGESTOKEN` and `NUGET_KEY` lists here: https://github.com/organizations/LBHackney-IT/settings/secrets/actions. 
- Apply the same changes to the 
![Screenshot 2024-09-30 at 15 08 (Brave Browser)@2x](https://github.com/user-attachments/assets/3e83a359-1812-411c-8e74-dd4fb6229f89)
other 9 repositories in that list:
