### PR TITLE
TS-1614: Adding data about the end of an assetContract 

### DIFF
--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -59,8 +59,8 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.TargetType.Should().Be(queryableAssetContract.TargetType);
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
-            domainContract.EndDate.Should().Be(queryableAssetContract.EndDate);  
-            domainContract.EndReason.Should().Be(queryableAssetContract.EndReason);         
+            domainContract.EndDate.Should().Be(queryableAssetContract.EndDate);
+            domainContract.EndReason.Should().Be(queryableAssetContract.EndReason);
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
             domainContract.ApprovalStatus.Should().Be(queryableAssetContract.ApprovalStatus);
             domainContract.ApprovalStatusReason.Should().Be(queryableAssetContract.ApprovalStatusReason);

--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -59,6 +59,8 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.TargetType.Should().Be(queryableAssetContract.TargetType);
             domainContract.StartDate.Should().Be(queryableAssetContract.StartDate);
             domainContract.ApprovalDate.Should().Be(queryableAssetContract.ApprovalDate);
+            domainContract.EndDate.Should().Be(queryableAssetContract.EndDate);  
+            domainContract.EndReason.Should().Be(queryableAssetContract.EndReason);         
             domainContract.IsApproved.Should().Be(queryableAssetContract.IsApproved);
             domainContract.ApprovalStatus.Should().Be(queryableAssetContract.ApprovalStatus);
             domainContract.ApprovalStatusReason.Should().Be(queryableAssetContract.ApprovalStatusReason);

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -12,6 +12,8 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string TargetType { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public string EndReason { get; set; }
         public bool? IsApproved { get; set; }
         public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -12,6 +12,8 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public string TargetType { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public string EndReason { get; set; }        
         public bool? IsApproved { get; set; }
         public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -13,7 +13,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public DateTime? EndDate { get; set; }
-        public string EndReason { get; set; }        
+        public string EndReason { get; set; }
         public bool? IsApproved { get; set; }
         public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -91,7 +91,7 @@ namespace Hackney.Shared.HousingSearch.Factories
                 TargetType = entity.TargetType,
                 StartDate = entity.StartDate,
                 EndDate = entity.EndDate,
-                EndReason= entity.EndReason,
+                EndReason = entity.EndReason,
                 ApprovalDate = entity.ApprovalDate,
                 IsApproved = entity.IsApproved,
                 ApprovalStatus = entity.ApprovalStatus,

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -90,6 +90,8 @@ namespace Hackney.Shared.HousingSearch.Factories
                 TargetId = entity.TargetId,
                 TargetType = entity.TargetType,
                 StartDate = entity.StartDate,
+                EndDate = entity.EndDate,
+                EndReason= entity.EndReason,
                 ApprovalDate = entity.ApprovalDate,
                 IsApproved = entity.IsApproved,
                 ApprovalStatus = entity.ApprovalStatus,

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -15,7 +15,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
         public DateTime? EndDate { get; set; }
-        public string EndReason { get; set; }        
+        public string EndReason { get; set; }
         public bool? IsApproved { get; set; }
         public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -14,6 +14,8 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public string TargetType { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? ApprovalDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public string EndReason { get; set; }        
         public bool? IsApproved { get; set; }
         public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1614

## Describe this PR

### *What is the problem we're trying to solve*

BTA users need a way to cancel invalid contracts (contracts opened in error) so that approval will no longer be required and no payment will be made to agent/landlord.
To do so, we need to see data about when and why a Contract was ended in the Asset information, as it will inform the decision about display a Contract for approval on BTA.

### *What changes have we introduced*

Two properties for the Contract, wherever it appears on the Shared Package.

### *Follow up actions after merging PR*

Updating the Listener and API