### PR TITLE
TS-1631: Display multiple pending contracts for the same property

### DIFF
--- a/Hackney.Shared.HousingSearch/Domain/Asset/Asset.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Asset.cs
@@ -1,13 +1,15 @@
+using System.Collections.Generic;
+
 namespace Hackney.Shared.HousingSearch.Domain.Asset
 {
     public class Asset
     {
         public static Asset CreateAll(string id, string assetId, string assetType,
             bool isAssetCautionaryAlerted, AssetAddress assetAddress, Tenure tenure, string rootAsset, string parentAssetIds,
-            AssetCharacteristics assetCharacteristics, AssetManagement assetManagement, AssetLocation assetLocation, bool isActive, Contract contract)
+            AssetCharacteristics assetCharacteristics, AssetManagement assetManagement, AssetLocation assetLocation, bool isActive, IEnumerable<Contract> contracts)
         {
             return new Asset(id, assetId, assetType, isAssetCautionaryAlerted, assetAddress, tenure, rootAsset,
-                parentAssetIds, assetCharacteristics, assetManagement, assetLocation, isActive, contract);
+                parentAssetIds, assetCharacteristics, assetManagement, assetLocation, isActive, contracts);
         }
 
         public static Asset Create(string id, string assetId, string assetType,
@@ -35,7 +37,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         }
         private Asset(string id, string assetId, string assetType,
             bool isAssetCautionaryAlerted, AssetAddress assetAddress, Tenure tenure, string rootAsset, string parentAssetIds,
-             AssetCharacteristics assetCharacteristics, AssetManagement assetManagement, AssetLocation assetLocation, bool isActive, Contract contract)
+             AssetCharacteristics assetCharacteristics, AssetManagement assetManagement, AssetLocation assetLocation, bool isActive, IEnumerable<Contract> contracts)
         {
             Id = id;
             AssetId = assetId;
@@ -49,7 +51,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
             AssetCharacteristics = assetCharacteristics;
             AssetManagement = assetManagement;
             AssetLocation = assetLocation;
-            AssetContract = contract;
+            AssetContracts = contracts;
         }
 
         public string Id { get; set; }
@@ -76,6 +78,6 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string AssetStatus { get; set; }
 
         public AssetLocation AssetLocation { get; set; }
-        public Contract AssetContract { get; set; }
+        public IEnumerable<Contract> AssetContracts { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -3,7 +3,7 @@ using DomainProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
 using System.Collections.Generic;
 using System.Linq;
 using System;
-using Hackney.Shared.HousingSearch.Domain.Asset;
+using Contract = Hackney.Shared.HousingSearch.Domain.Asset.Contract;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using RelatedEntity = Hackney.Shared.HousingSearch.Domain.Process.RelatedEntity;
 using PatchAssignment = Hackney.Shared.HousingSearch.Domain.Process.PatchAssignment;
@@ -11,7 +11,6 @@ using Hackney.Shared.HousingSearch.Domain.Tenure;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
-using Contract = Hackney.Shared.HousingSearch.Domain.Asset.Contract;
 
 namespace Hackney.Shared.HousingSearch.Factories
 {

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -3,6 +3,7 @@ using DomainProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using Hackney.Shared.HousingSearch.Domain.Asset;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using RelatedEntity = Hackney.Shared.HousingSearch.Domain.Process.RelatedEntity;
 using PatchAssignment = Hackney.Shared.HousingSearch.Domain.Process.PatchAssignment;
@@ -10,6 +11,7 @@ using Hackney.Shared.HousingSearch.Domain.Tenure;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
+using Contract = Hackney.Shared.HousingSearch.Domain.Asset.Contract;
 
 namespace Hackney.Shared.HousingSearch.Factories
 {
@@ -129,9 +131,14 @@ namespace Hackney.Shared.HousingSearch.Factories
             };
         }
 
+
         public static IEnumerable<RelatedPeople> ToDomain(this IEnumerable<QueryableRelatedPeople> relatedPeople)
         {
             return relatedPeople.Select(x => x.ToDomain());
+        }
+        public static IEnumerable<Contract> ToDomain(this IEnumerable<QueryableAssetContract> contracts)
+        {
+            return contracts.Select(x => x.ToDomain());
         }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Hackney.Shared.HousingSearch.Factories;
 using Nest;
 using Asset = Hackney.Shared.HousingSearch.Domain.Asset.Asset;
@@ -157,7 +158,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                     AssetLocation.FloorNo
                 );
 
-            var contract = AssetContract?.ToDomain();
+            var contracts = AssetContracts?.ToDomain();
 
             return Asset.CreateAll(
                 Id,
@@ -172,7 +173,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                 assetManagement,
                 assetLocation,
                 IsActive,
-                contract
+                contracts
             );
         }
 
@@ -210,6 +211,6 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
 
         public QueryableAssetLocation AssetLocation { get; set; }
 
-        public QueryableAssetContract AssetContract { get; set; }
+        public List<QueryableAssetContract> AssetContracts { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1631

## Describe this PR

### *What is the problem we're trying to solve*

On BTA, the Contracts approval Worktray relies on the Housing Search system to display what contract belongs to which asset. Currently, only the latest contract is saved by the Listener, however, in some instances, BTA users will need to approve more than one contract on the same property. This happens, for example, if a tenant moves in and out of the property in a matter of days: since the contract approval is not guaranteed to be done on a daily basis, those contracts would not be approved in time.
The changes in this and following PRs will move `AssetContract ` property on the `Asset `entity from a single one to a list of `AssetContracts`.

### *What changes have we introduced*

Change from single AssetContract to list of AssetContracts where needed.

### *Follow up actions after merging PR*

Updates to Listener and API.