### PR TITLE
TS-1698 add support for temporary accommodation blocks

### DIFF
--- a/Hackney.Shared.HousingSearch/Domain/Asset/AssetManagement.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/AssetManagement.cs
@@ -6,7 +6,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
     {
         public static AssetManagement Create(string agent, string areaOfficeName, bool isCouncilProperty, string managingOrganisation,
             Guid managingOrganisationId, string owner, bool isTMOManaged, string propertyOccupiedStatus, bool isNoRepairsMaintenance,
-            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId)
+            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId, bool? isPartOfTemporaryAccommodationBlock)
         {
             return new AssetManagement(
                 agent,
@@ -20,14 +20,15 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
                 isNoRepairsMaintenance,
                 isTemporaryAccomodation,
                 isTemporaryAccommodationBlock,
-                temporaryAccommodationParentAssetId
+                temporaryAccommodationParentAssetId,
+                isPartOfTemporaryAccommodationBlock
             );
         }
         public AssetManagement() { }
 
         private AssetManagement(string agent, string areaOfficeName, bool isCouncilProperty, string managingOrganisation,
             Guid managingOrganisationId, string owner, bool isTMOManaged, string propertyOccupiedStatus, bool isNoRepairsMaintenance,
-            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId)
+            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId, bool? isPartOfTemporaryAccommodationBlock)
         {
             Agent = agent;
             AreaOfficeName = areaOfficeName;
@@ -41,6 +42,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
             IsTemporaryAccomodation = isTemporaryAccomodation;
             IsTemporaryAccommodationBlock = isTemporaryAccommodationBlock;
             TemporaryAccommodationParentAssetId = temporaryAccommodationParentAssetId;
+            IsPartOfTemporaryAccommodationBlock = isPartOfTemporaryAccommodationBlock;
         }
 
         public string Agent { get; set; }
@@ -55,5 +57,6 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public bool IsTemporaryAccomodation { get; set; }
         public bool? IsTemporaryAccommodationBlock { get; set; }
         public Guid? TemporaryAccommodationParentAssetId { get; set; }
+        public bool? IsPartOfTemporaryAccommodationBlock { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Domain/Asset/AssetManagement.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/AssetManagement.cs
@@ -6,7 +6,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
     {
         public static AssetManagement Create(string agent, string areaOfficeName, bool isCouncilProperty, string managingOrganisation,
             Guid managingOrganisationId, string owner, bool isTMOManaged, string propertyOccupiedStatus, bool isNoRepairsMaintenance,
-            bool isTemporaryAccomodation)
+            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId)
         {
             return new AssetManagement(
                 agent,
@@ -18,14 +18,16 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
                 isTMOManaged,
                 propertyOccupiedStatus,
                 isNoRepairsMaintenance,
-                isTemporaryAccomodation
+                isTemporaryAccomodation,
+                isTemporaryAccommodationBlock,
+                temporaryAccommodationParentAssetId
             );
         }
         public AssetManagement() { }
 
         private AssetManagement(string agent, string areaOfficeName, bool isCouncilProperty, string managingOrganisation,
             Guid managingOrganisationId, string owner, bool isTMOManaged, string propertyOccupiedStatus, bool isNoRepairsMaintenance,
-            bool isTemporaryAccomodation)
+            bool isTemporaryAccomodation, bool? isTemporaryAccommodationBlock, Guid? temporaryAccommodationParentAssetId)
         {
             Agent = agent;
             AreaOfficeName = areaOfficeName;
@@ -37,6 +39,8 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
             PropertyOccupiedStatus = propertyOccupiedStatus;
             IsNoRepairsMaintenance = isNoRepairsMaintenance;
             IsTemporaryAccomodation = isTemporaryAccomodation;
+            IsTemporaryAccommodationBlock = isTemporaryAccommodationBlock;
+            TemporaryAccommodationParentAssetId = temporaryAccommodationParentAssetId;
         }
 
         public string Agent { get; set; }
@@ -49,5 +53,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string PropertyOccupiedStatus { get; set; }
         public bool IsNoRepairsMaintenance { get; set; }
         public bool IsTemporaryAccomodation { get; set; }
+        public bool? IsTemporaryAccommodationBlock { get; set; }
+        public Guid? TemporaryAccommodationParentAssetId { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
 using Hackney.Shared.HousingSearch.Factories;
 using Nest;
+using System.Collections.Generic;
 using Asset = Hackney.Shared.HousingSearch.Domain.Asset.Asset;
 
 namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
@@ -149,7 +149,9 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                     AssetManagement.IsTMOManaged,
                     AssetManagement.PropertyOccupiedStatus,
                     AssetManagement.IsNoRepairsMaintenance,
-                    AssetManagement.IsTemporaryAccomodation
+                    AssetManagement.IsTemporaryAccomodation,
+                    AssetManagement.IsTemporaryAccommodationBlock,
+                    AssetManagement.TemporaryAccommodationParentAssetId
                 );
 
             var assetLocation = AssetLocation == null

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAsset.cs
@@ -151,7 +151,8 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
                     AssetManagement.IsNoRepairsMaintenance,
                     AssetManagement.IsTemporaryAccomodation,
                     AssetManagement.IsTemporaryAccommodationBlock,
-                    AssetManagement.TemporaryAccommodationParentAssetId
+                    AssetManagement.TemporaryAccommodationParentAssetId,
+                    AssetManagement.IsPartOfTemporaryAccommodationBlock
                 );
 
             var assetLocation = AssetLocation == null

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetManagement.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetManagement.cs
@@ -16,5 +16,6 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public bool IsTemporaryAccomodation { get; set; }
         public bool? IsTemporaryAccommodationBlock { get; set; }
         public Guid? TemporaryAccommodationParentAssetId { get; set; }
+        public bool? IsPartOfTemporaryAccommodationBlock { get; set; }
     }
 }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetManagement.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetManagement.cs
@@ -14,5 +14,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public string PropertyOccupiedStatus { get; set; }
         public bool IsNoRepairsMaintenance { get; set; }
         public bool IsTemporaryAccomodation { get; set; }
+        public bool? IsTemporaryAccommodationBlock { get; set; }
+        public Guid? TemporaryAccommodationParentAssetId { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1698](https://hackney.atlassian.net/browse/TS-1698)

## Describe this PR

### *What is the problem we're trying to solve*

This adds support for the same three new properties for temporary accommodation already implemented in the asset information api. Please see [PR](https://github.com/LBHackney-IT/asset-information-api/pull/153) and [PR](https://github.com/LBHackney-IT/asset-information-api/pull/158) 

### *What changes have we introduced*
1. Adds optional `isTemporaryAccommodationBlock`, `temporaryAccommodationParentAssetId` and `isPartOfTemporaryAccommodationBlock` properties to `QueryableAssetManagement`. These properties are required in order to implement front end changes required for showing block details.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update the search listener and API by implementing these new properties.

[TS-1698]: https://hackney.atlassian.net/browse/TS-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ