### PR TITLE
TS-2111 add contract stage

### DIFF
--- a/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
+++ b/Hackney.Shared.HousingSearch.Tests/Factories/DomainFactoryTests.cs
@@ -66,6 +66,7 @@ namespace Hackney.Shared.HousingSearch.Tests.Factories
             domainContract.IsActive.Should().Be(queryableAssetContract.IsActive);
             domainContract.Charges.Should().BeEquivalentTo(queryableAssetContract.Charges);
             domainContract.RelatedPeople.Should().BeEquivalentTo(queryableAssetContract.RelatedPeople);
+            domainContract.Stage.Should().Be(queryableAssetContract.Stage);
         }
 
         [Fact]

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -16,7 +16,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
-        public string Stage { get; set; }
+        public int Stage { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
         public IEnumerable<RelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -16,7 +16,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
-        public int Stage { get; set; }
+        public int? Stage { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
         public IEnumerable<RelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Asset/Contract.cs
@@ -16,6 +16,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Asset
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
+        public string Stage { get; set; }
         public IEnumerable<Charges> Charges { get; set; }
         public IEnumerable<RelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -16,6 +16,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
+        public string Stage { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
+++ b/Hackney.Shared.HousingSearch/Domain/Contract/Contract.cs
@@ -16,7 +16,7 @@ namespace Hackney.Shared.HousingSearch.Domain.Contract
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
-        public string Stage { get; set; }
+        public int? Stage { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
+++ b/Hackney.Shared.HousingSearch/Factories/DomainFactory.cs
@@ -1,16 +1,16 @@
-using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
-using DomainProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
-using System.Collections.Generic;
-using System.Linq;
-using System;
-using Contract = Hackney.Shared.HousingSearch.Domain.Asset.Contract;
 using Hackney.Shared.HousingSearch.Domain.Contract;
-using RelatedEntity = Hackney.Shared.HousingSearch.Domain.Process.RelatedEntity;
-using PatchAssignment = Hackney.Shared.HousingSearch.Domain.Process.PatchAssignment;
 using Hackney.Shared.HousingSearch.Domain.Tenure;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Contract = Hackney.Shared.HousingSearch.Domain.Asset.Contract;
+using DomainProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
+using PatchAssignment = Hackney.Shared.HousingSearch.Domain.Process.PatchAssignment;
+using RelatedEntity = Hackney.Shared.HousingSearch.Domain.Process.RelatedEntity;
 
 namespace Hackney.Shared.HousingSearch.Factories
 {
@@ -99,6 +99,7 @@ namespace Hackney.Shared.HousingSearch.Factories
                 IsActive = entity.IsActive,
                 Charges = entity.Charges?.ToDomain(),
                 RelatedPeople = entity.RelatedPeople?.ToDomain(),
+                Stage = entity.Stage
             };
         }
 

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -18,7 +18,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
-        public string Stage { get; set; }
+        public int Stage { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -18,7 +18,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
-        public int Stage { get; set; }
+        public int? Stage { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }

--- a/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
+++ b/Hackney.Shared.HousingSearch/Gateways/Models/Assets/QueryableAssetContract.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+﻿using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Nest;
+using System;
 using System.Collections.Generic;
 
 namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
@@ -18,6 +18,7 @@ namespace Hackney.Shared.HousingSearch.Gateways.Models.Assets
         public string ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? IsActive { get; set; }
+        public string Stage { get; set; }
         public IEnumerable<QueryableCharges> Charges { get; set; }
         public IEnumerable<QueryableRelatedPeople> RelatedPeople { get; set; }
     }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2111](https://hackney.atlassian.net/browse/TS-2111)

## Describe this PR

### *What is the problem we're trying to solve*

Currently the Contract model doesn't have stage, so we don't have that value available in assets search. We need that in order to display correct labels etc.

### *What changes have we introduced*

1. Add stage to domain contract. Not all contracts will have stage to begin with, so the property has been made optional 
2. Add stage to `QueryableAssetContract`

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.

[TS-2111]: https://hackney.atlassian.net/browse/TS-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ